### PR TITLE
A few cleanup items:

### DIFF
--- a/kin-starter-ios/ViewController.swift
+++ b/kin-starter-ios/ViewController.swift
@@ -147,9 +147,7 @@ class ViewController: UIViewController {
         view.addSubview(addToTestBalanceButton)
         view.addSubview(sendKinButton)
         
-        setupKin()
-        
-        checkKinBalance()
+        setupKin()        
     }
     
     override func viewWillLayoutSubviews() {


### PR DESCRIPTION
- in ViewController.swift, there is no need to check the balance in viewDidLoad, as setupKin will fire via the onPayments completion block, which already checks the balance
- Updates some documentation to ensure thread management is clear
- Updates completion blocks for public functions to fire on main thread in all cases
- There was a case in the checkBalance function where, if the context had not been initialized, the completion block would not get fired This updates to make sure the completion block will still fire in all cases, and show the appropriate error if the context has not been initialized